### PR TITLE
Schedule task check on every device boot

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -90,5 +90,16 @@
     <orderEntry type="library" exported="" name="support-v4-22.0.0" level="project" />
     <orderEntry type="library" exported="" name="retrofit-1.9.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-22.0.0" level="project" />
+    <orderEntry type="module-library" scope="TEST">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/junit-4.11.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/hamcrest-core-1.3.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/hamcrest-library-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,11 +3,13 @@
     package="hr.tvz.natjecanje" >
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application android:name="hr.tvz.natjecanje.karmapp.KarmApp"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:installLocation="internalOnly"
         android:theme="@style/AppTheme" >
         <activity
             android:name=".karmapp.activities.IntroActivity"
@@ -22,6 +24,12 @@
             android:name=".karmapp.activities.MainActivity"
             android:label="@string/title_activity_main" >
         </activity>
+
+        <receiver android:name="hr.tvz.natjecanje.karmapp.receivers.BootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/hr/tvz/natjecanje/karmapp/receivers/BootReceiver.java
+++ b/app/src/main/java/hr/tvz/natjecanje/karmapp/receivers/BootReceiver.java
@@ -1,0 +1,53 @@
+package hr.tvz.natjecanje.karmapp.receivers;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Created by Tomislav on 30.3.2015..
+ */
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+
+            Intent taskCheckIntent = new Intent(context, TaskCheckReceiver.class);
+            PendingIntent pendingIntent = PendingIntent.getBroadcast(
+                    context,
+                    TaskCheckReceiver.REQUEST_CODE,
+                    taskCheckIntent,
+                    PendingIntent.FLAG_CANCEL_CURRENT);
+
+            long firstTriggerTime = getTimestampToday(12);
+
+            alarmManager.setRepeating(
+                    AlarmManager.RTC_WAKEUP,
+                    firstTriggerTime,
+                    AlarmManager.INTERVAL_DAY,
+                    pendingIntent
+            );
+
+            if (firstTriggerTime < new Date().getTime()) {
+                alarmManager.setRepeating(
+                        AlarmManager.RTC_WAKEUP,
+                        firstTriggerTime,
+                        AlarmManager.INTERVAL_DAY,
+                        pendingIntent
+                );
+            }
+        }
+    }
+
+    private long getTimestampToday(int hour) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR_OF_DAY, hour);
+        return calendar.getTimeInMillis();
+    }
+}

--- a/app/src/main/java/hr/tvz/natjecanje/karmapp/receivers/TaskCheckReceiver.java
+++ b/app/src/main/java/hr/tvz/natjecanje/karmapp/receivers/TaskCheckReceiver.java
@@ -1,0 +1,17 @@
+package hr.tvz.natjecanje.karmapp.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Created by Tomislav on 30.3.2015..
+ */
+public class TaskCheckReceiver extends BroadcastReceiver {
+    public static final int REQUEST_CODE = 1628;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+    }
+}


### PR DESCRIPTION
Every time the device boots schedule daily task checks. The task check starts on the day the device is booted and if the predetermined time has already passed execute a check immediately.